### PR TITLE
Feature: added multi-category selection to the filter with an add or remove list

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A React-based expense tracking application that allows users to view recent expe
 
 **Story 3: Expense Filter Component**
 
-"As a user, I want to filter my expenses by category so that I can easily view and analyze my spending habits".
+"As a user, I want to filter my expenses by one or more categories so that I can easily view and analyze my spending habits". (sprint 2)
 
 ## Front-End Deployment
 

--- a/vite-project/src/components/expense-filter/ExpenseFilter.css
+++ b/vite-project/src/components/expense-filter/ExpenseFilter.css
@@ -14,4 +14,4 @@
   border-bottom: none;
 }
 
-/* Container styles removed - now handled by ListPanel component */
+/* Panel container styling is in ListPanel.css */

--- a/vite-project/src/components/expense-filter/ExpenseFilter.tsx
+++ b/vite-project/src/components/expense-filter/ExpenseFilter.tsx
@@ -1,41 +1,85 @@
-import { useState } from "react";
 import type { Expense, ExpenseCategory } from "../../types";
 import "./ExpenseFilter.css";
-import ListPanel from '../shared/ListPanel';
+import ListPanel from "../shared/ListPanel";
+
+const ALL_CATEGORIES: ExpenseCategory[] = [
+  "Food",
+  "Transport",
+  "Housing",
+  "Entertainment",
+  "Shopping",
+  "Health",
+];
 
 type Props = {
   expenses: Expense[];
+  selectedCategories: ExpenseCategory[];
+  setSelectedCategories: React.Dispatch<React.SetStateAction<ExpenseCategory[]>>;
 };
 
-function ExpenseFilter({ expenses }: Props) {
-  // Default category state "Shopping"
-  const [selectedCategory, setSelectedCategory] =
-    useState<ExpenseCategory>("Shopping");
+function ExpenseFilter({
+  expenses,
+  selectedCategories,
+  setSelectedCategories,
+}: Props) {
+  const handleAddCategory = (category: ExpenseCategory) => {
+    if (selectedCategories.includes(category)) return;
+    setSelectedCategories((prev) => [...prev, category]);
+  };
 
-  // Filter the expenses by the selected category
+  const handleRemoveCategory = (category: ExpenseCategory) => {
+    setSelectedCategories((prev) =>
+      prev.filter((selectedCategory) => selectedCategory !== category)
+    );
+  };
+
+  const handleReset = () => {
+    setSelectedCategories([]);
+  };
+
   const filteredExpenses = expenses.filter(
-    (expense) => expense.category === selectedCategory
+    (expense) =>
+      selectedCategories.length === 0 ||
+      selectedCategories.includes(expense.category)
   );
 
   return (
     <ListPanel title="Filter by Category">
-      {/* T.3 display shared state */}
       <p>Total expenses (shared): {expenses.length}</p>
 
-      <label htmlFor="category-select">Select Category: </label>
+      <label htmlFor="category-select">Add category to filter: </label>
       <select
         id="category-select"
-        value={selectedCategory}
-        onChange={(e) => setSelectedCategory(e.target.value as ExpenseCategory)}
+        value=""
+        onChange={(event) => {
+          const value = event.target.value as ExpenseCategory;
+          if (value) handleAddCategory(value);
+        }}
       >
-        <option value="Food">Food</option>
-        <option value="Transport">Transport</option>
-        <option value="Housing">Housing</option>
-        <option value="Entertainment">Entertainment</option>
-        <option value="Shopping">Shopping</option>
-        <option value="Health">Health</option>
+        <option value="">-- Add a category --</option>
+        {ALL_CATEGORIES.map((category) => (
+          <option key={category} value={category}>
+            {category}
+          </option>
+        ))}
       </select>
 
+      <p>Selected categories:</p>
+      <ul>
+        {selectedCategories.map((category) => (
+          <li key={category}>
+            {category}{" "}
+            <button onClick={() => handleRemoveCategory(category)}>
+              Remove
+            </button>
+          </li>
+        ))}
+      </ul>
+      <button onClick={handleReset}>
+        Reset selections
+      </button>
+
+      <p>Filtered expenses ({filteredExpenses.length}):</p>
       <ul>
         {filteredExpenses.map((expense) => (
           <li key={expense.id}>

--- a/vite-project/src/pages/ExpenseFilterPage.tsx
+++ b/vite-project/src/pages/ExpenseFilterPage.tsx
@@ -1,4 +1,5 @@
-import type { Expense } from "../types";
+import { useState } from "react";
+import type { Expense, ExpenseCategory } from "../types";
 import ExpenseFilter from "../components/expense-filter/ExpenseFilter";
 
 type Props = {
@@ -7,6 +8,9 @@ type Props = {
 };
 
 const ExpenseFilterPage = ({ expenses, setExpenses }: Props) => {
+  const [selectedCategories, setSelectedCategories] = useState<ExpenseCategory[]>(["Shopping"]);
+
+  /* Demo: modify shared expenses list (for testing shared state across pages) */
   const addTestExpense = () => {
     setExpenses((prev) => [
       {
@@ -36,7 +40,11 @@ const ExpenseFilterPage = ({ expenses, setExpenses }: Props) => {
         Remove One Expense
       </button>
 
-      <ExpenseFilter expenses={expenses} />
+      <ExpenseFilter
+        expenses={expenses}
+        selectedCategories={selectedCategories}
+        setSelectedCategories={setSelectedCategories}
+      />
     </section>
   );
 };


### PR DESCRIPTION
Sprint 2: Expense Filter feature page (I.1–I.3)

Dropdown adds category to a visible list when selected, and you can remove selections via list item or Reset button. 
State lifted to page - form receives state/setter as props, with a validation check for duplicate selection
README.md - I updated my user story to reflect sprint 2