### PR TITLE
feat(filter): filter presets with Clerk and user login

### DIFF
--- a/apps/frontend/.env.development
+++ b/apps/frontend/.env.development
@@ -1,0 +1,2 @@
+# Base URL for API calls (apiClient). Must include /api so routes like /expenses hit /api/expenses on the backend.
+VITE_API_URL=http://localhost:3000/api

--- a/apps/frontend/src/apis/filterPresetRepo.ts
+++ b/apps/frontend/src/apis/filterPresetRepo.ts
@@ -1,28 +1,24 @@
+import { fetchWithAuth } from "./apiClient";
 import type { FilterPreset } from "../../../../shared/types";
 
-const API_BASE_URL = "http://localhost:3000/api/filter-presets";
-
-export async function getAll(): Promise<FilterPreset[]> {
-  const response = await fetch(API_BASE_URL);
-  if (!response.ok) throw new Error("Failed to load presets");
-  return response.json();
+export async function getAll(token: string): Promise<FilterPreset[]> {
+  return await fetchWithAuth("/presets", { method: "GET" }, token);
 }
 
 export async function add(
-  preset: Omit<FilterPreset, "id">
+  preset: Omit<FilterPreset, "id">,
+  token: string,
 ): Promise<FilterPreset> {
-  const response = await fetch(API_BASE_URL, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(preset),
-  });
-  if (!response.ok) throw new Error("Failed to save preset");
-  return response.json();
+  return await fetchWithAuth(
+    "/presets",
+    {
+      method: "POST",
+      body: JSON.stringify(preset),
+    },
+    token,
+  );
 }
 
-export async function deletePreset(id: number): Promise<void> {
-  const response = await fetch(`${API_BASE_URL}/${id}`, {
-    method: "DELETE",
-  });
-  if (!response.ok) throw new Error("Failed to delete preset");
+export async function deletePreset(id: number, token: string): Promise<void> {
+  await fetchWithAuth(`/presets/${id}`, { method: "DELETE" }, token);
 }

--- a/apps/frontend/src/components/category-summary/CategorySummary.tsx
+++ b/apps/frontend/src/components/category-summary/CategorySummary.tsx
@@ -21,7 +21,7 @@ export default function CategorySummary() {
       try {
         const token = await getToken();
         const response = await fetch(
-          `${import.meta.env.VITE_API_URL}/api/my-budgets`,
+          `${import.meta.env.VITE_API_URL}/my-budgets`,
           {
             headers: { Authorization: `Bearer ${token}` },
           },

--- a/apps/frontend/src/components/recent-expenses/AddExpenseForm.tsx
+++ b/apps/frontend/src/components/recent-expenses/AddExpenseForm.tsx
@@ -24,7 +24,7 @@ export const AddExpenseForm = () => {
 
     try {
       const token = await getToken();
-      const response = await fetch(`${import.meta.env.VITE_API_URL}/api/expenses`, {
+      const response = await fetch(`${import.meta.env.VITE_API_URL}/expenses`, {
         method: "POST",
         headers: { 
             "Content-Type": "application/json",

--- a/apps/frontend/src/components/recent-expenses/RecentExpenses.tsx
+++ b/apps/frontend/src/components/recent-expenses/RecentExpenses.tsx
@@ -15,7 +15,7 @@ export const RecentExpenses = () => {
       if (!isLoaded || !isSignedIn) return;
       try {
         const token = await getToken();
-        const response = await fetch(`${import.meta.env.VITE_API_URL}/api/expenses`, {
+        const response = await fetch(`${import.meta.env.VITE_API_URL}/expenses`, {
           headers: { 'Authorization': `Bearer ${token}` }
         });
         if (response.ok) {
@@ -32,7 +32,7 @@ export const RecentExpenses = () => {
   const handleRemove = async (id: number) => {
     try {
       const token = await getToken();
-      const response = await fetch(`${import.meta.env.VITE_API_URL}/api/expenses/${id}`, {
+      const response = await fetch(`${import.meta.env.VITE_API_URL}/expenses/${id}`, {
         method: 'DELETE',
         headers: { 'Authorization': `Bearer ${token}` }
       });

--- a/apps/frontend/src/hooks/useFilterPresets.ts
+++ b/apps/frontend/src/hooks/useFilterPresets.ts
@@ -1,4 +1,5 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { useAuth } from "@clerk/clerk-react";
 import type { FilterPreset } from "../../../../shared/types";
 import {
   getAllPresets,
@@ -7,26 +8,77 @@ import {
 } from "../services/filterPresetService";
 
 export function useFilterPresets() {
+  const { getToken, isLoaded, isSignedIn } = useAuth();
   const [presets, setPresets] = useState<FilterPreset[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-  const refreshPresets = async () => {
-    const next = await getAllPresets();
-    setPresets(next);
-  };
+  const refreshPresets = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const token = await getToken();
+      if (!token) {
+        setPresets([]);
+        return;
+      }
+      const next = await getAllPresets(token);
+      setPresets(next);
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : "Failed to load presets.";
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [getToken]);
 
   useEffect(() => {
+    if (!isLoaded) return;
+
+    if (!isSignedIn) {
+      setPresets([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
     void refreshPresets();
-  }, []);
+  }, [isLoaded, isSignedIn, refreshPresets]);
 
-  const addPreset = async (preset: Omit<FilterPreset, "id">) => {
-    await serviceAddPreset(preset);
-    await refreshPresets();
+  const addPreset = async (
+    preset: Omit<FilterPreset, "id">,
+  ): Promise<boolean> => {
+    try {
+      const token = await getToken();
+      if (!token) throw new Error("Unauthorized");
+
+      await serviceAddPreset(preset, token);
+      await refreshPresets();
+      return true;
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : "Failed to save preset.";
+      setError(message);
+      return false;
+    }
   };
 
-  const removePreset = async (id: number) => {
-    await deletePreset(id);
-    await refreshPresets();
+  const removePreset = async (id: number): Promise<boolean> => {
+    try {
+      const token = await getToken();
+      if (!token) throw new Error("Unauthorized");
+
+      await deletePreset(id, token);
+      await refreshPresets();
+      return true;
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : "Failed to delete preset.";
+      setError(message);
+      return false;
+    }
   };
 
-  return { presets, addPreset, removePreset };
+  return { presets, addPreset, removePreset, loading, error };
 }

--- a/apps/frontend/src/pages/ExpenseFilterPage.tsx
+++ b/apps/frontend/src/pages/ExpenseFilterPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useAuth } from "@clerk/clerk-react";
 import type { ExpenseCategory } from "../../../../shared/types";
 import ExpenseFilter from "../components/expense-filter/ExpenseFilter";
 import { useExpenses } from "../hooks/useExpenses";
@@ -10,24 +11,53 @@ import { useFilterPresets } from "../hooks/useFilterPresets";
  * through that architecture
  */
 const ExpenseFilterPage = () => {
-  const { expenses, addExpense, removeExpense } = useExpenses();
-  const { presets, addPreset } = useFilterPresets();
-  const [selectedCategories, setSelectedCategories] = useState<ExpenseCategory[]>(["Shopping"]);
+  const { isLoaded, isSignedIn } = useAuth();
+  const {
+    expenses,
+    addExpense,
+    removeExpense,
+    loading: expensesLoading,
+    error: expensesError,
+  } = useExpenses();
+  const {
+    presets,
+    addPreset,
+    removePreset,
+    loading: presetsLoading,
+    error: presetsError,
+  } = useFilterPresets();
+  const [selectedCategories, setSelectedCategories] = useState<
+    ExpenseCategory[]
+  >(["Shopping"]);
   const [presetName, setPresetName] = useState("");
+  const [presetSelectValue, setPresetSelectValue] = useState("");
 
   const handlePresetSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const id = e.target.value;
+    setPresetSelectValue(id);
     if (id) {
       const preset = presets.find((p) => p.id === Number(id));
-      if (preset) setSelectedCategories(preset.selectedCategories);
+      if (preset) {
+        setSelectedCategories(
+          preset.selectedCategories as ExpenseCategory[],
+        );
+        queueMicrotask(() => setPresetSelectValue(""));
+      }
     }
   };
 
-  const handleSavePreset = () => {
+  const handleSavePreset = async () => {
     const name = presetName.trim();
     if (!name) return;
-    addPreset({ name, selectedCategories: [...selectedCategories] });
-    setPresetName("");
+    const ok = await addPreset({
+      name,
+      selectedCategories: [...selectedCategories],
+    });
+    if (ok) setPresetName("");
+  };
+
+  const handleDeletePreset = async (id: number) => {
+    await removePreset(id);
   };
 
   /* Demo: modify shared expenses list (for testing shared state across pages) */
@@ -49,6 +79,13 @@ const ExpenseFilterPage = () => {
     <section>
       <h2>Expense Filter Page</h2>
 
+      {expensesLoading && <p aria-live="polite">Loading expenses…</p>}
+      {expensesError && (
+        <p role="alert" style={{ color: "crimson" }}>
+          Expenses: {expensesError}
+        </p>
+      )}
+
       <p>Total expenses (shared): {expenses.length}</p>
 
       <button onClick={addTestExpense}>Add Test Expense</button>
@@ -57,21 +94,53 @@ const ExpenseFilterPage = () => {
       </button>
 
       <div style={{ marginTop: "1rem" }}>
+        {isLoaded && !isSignedIn && (
+          <p role="status">
+            Sign in to load, save, and delete filter presets.
+          </p>
+        )}
+
+        {presetsLoading && <p aria-live="polite">Loading presets…</p>}
+        {presetsError && (
+          <p role="alert" style={{ color: "crimson" }}>
+            Presets: {presetsError}
+          </p>
+        )}
+
         <label htmlFor="preset-select">Saved presets: </label>
         <select
           id="preset-select"
-          defaultValue=""
+          value={presetSelectValue}
           onChange={handlePresetSelect}
           aria-label="Select a saved filter preset"
+          disabled={!isSignedIn || presetsLoading}
         >
           <option value="">-- Select a preset --</option>
           {presets.map((p) => (
-            <option key={p.id} value={p.id}>
+            <option key={p.id} value={String(p.id)}>
               {p.name}
             </option>
           ))}
         </select>
       </div>
+
+      {presets.length > 0 && (
+        <ul style={{ marginTop: "0.5rem" }}>
+          {presets.map((p) => (
+            <li key={p.id}>
+              {p.name}{" "}
+              <button
+                type="button"
+                onClick={() => void handleDeletePreset(p.id)}
+                disabled={!isSignedIn || presetsLoading}
+                aria-label={`Delete preset ${p.name}`}
+              >
+                Delete
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
 
       <div style={{ marginTop: "0.5rem" }}>
         <label htmlFor="preset-name">Save as preset: </label>
@@ -82,8 +151,13 @@ const ExpenseFilterPage = () => {
           onChange={(e) => setPresetName(e.target.value)}
           placeholder="Preset name"
           aria-label="Preset name"
+          disabled={!isSignedIn || presetsLoading}
         />
-        <button type="button" onClick={handleSavePreset}>
+        <button
+          type="button"
+          onClick={() => void handleSavePreset()}
+          disabled={!isSignedIn || presetsLoading}
+        >
           Save as preset
         </button>
       </div>

--- a/apps/frontend/src/services/filterPresetService.ts
+++ b/apps/frontend/src/services/filterPresetService.ts
@@ -1,16 +1,17 @@
 import type { FilterPreset } from "../../../../shared/types";
 import * as filterPresetRepo from "../apis/filterPresetRepo";
 
-export async function getAllPresets(): Promise<FilterPreset[]> {
-  return await filterPresetRepo.getAll();
+export async function getAllPresets(token: string): Promise<FilterPreset[]> {
+  return await filterPresetRepo.getAll(token);
 }
 
 export async function addPreset(
-  preset: Omit<FilterPreset, "id">
+  preset: Omit<FilterPreset, "id">,
+  token: string,
 ): Promise<FilterPreset> {
-  return await filterPresetRepo.add(preset);
-}
-export async function deletePreset(id: number): Promise<void> {
-  await filterPresetRepo.deletePreset(id);
+  return await filterPresetRepo.add(preset, token);
 }
 
+export async function deletePreset(id: number, token: string): Promise<void> {
+  await filterPresetRepo.deletePreset(id, token);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,6 @@
       "version": "7.28.6",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -591,7 +590,6 @@
       "version": "24.10.9",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -643,7 +641,6 @@
       "version": "8.53.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -906,7 +903,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1029,7 +1025,6 @@
       "version": "9.39.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -1512,7 +1507,6 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1733,7 +1727,6 @@
       "version": "7.3.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -1831,7 +1824,6 @@
       "version": "4.3.5",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -2015,8 +2007,7 @@
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.15.tgz",
       "integrity": "sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ==",
       "devOptional": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@electric-sql/pglite-socket": {
       "version": "0.0.20",
@@ -2826,7 +2817,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -2862,7 +2852,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2921,7 +2910,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3668,7 +3656,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -4060,7 +4047,6 @@
       "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4777,7 +4763,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -5019,7 +5004,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/config": "7.5.0",
         "@prisma/dev": "0.20.0",
@@ -5168,7 +5152,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5178,7 +5161,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5898,7 +5880,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
- Set up saved filter presets to the real API using the same logged-in token as expenses.
- Updated the Expense Filter page: loading/errors, sign-in message, delete preset, fix preset dropdown.
- Add apps/frontend/.env.development so local API URL defaults to http://localhost:3000/app 
